### PR TITLE
Prevents duplicate operations - improves unit testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,10 +21,11 @@
 
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
-.env
+.env.sample
 .idea/
 0.0.*.json
 HCSToken.iml
 target/
 erc20.sol
 run-greg.sh
+.env

--- a/src/main/java/com/hedera/hcstoken/HCSToken.java
+++ b/src/main/java/com/hedera/hcstoken/HCSToken.java
@@ -69,40 +69,41 @@ public final class HCSToken
             System.out.print(String.format(" %s", argument));
         }
         System.out.println();
+        Transactions transactions = new Transactions();
 
         switch (args[0].toUpperCase()) {
             // primitives
             case "CONSTRUCT":
                 // construct {name} {symbol} {decimals}
-                Transactions.construct(token, args[1], args[2], parseInt(args[3]));
+                transactions.construct(token, args[1], args[2], parseInt(args[3]));
                 break;
             case "MINT":
                 // mint {quantity}
-                Transactions.mint(token, Long.parseLong(args[1]));
+                transactions.mint(token, Long.parseLong(args[1]));
                 break;
             case "TRANSFER":
                 // transfer {address} {quantity}
-                Transactions.transfer(token, args[1], Long.parseLong(args[2]));
+                transactions.transfer(token, args[1], Long.parseLong(args[2]));
                 break;
             case "APPROVE":
                 // approve {spender} {amount}
-                Transactions.approve(token, args[1], Long.parseLong(args[2]));
+                transactions.approve(token, args[1], Long.parseLong(args[2]));
                 break;
             case "INCREASEALLOWANCE":
                 // increaseAllowance {spender} {addedValue}
-                Transactions.increaseAllowance(token, args[1], Long.parseLong(args[2]));
+                transactions.increaseAllowance(token, args[1], Long.parseLong(args[2]));
                 break;
             case "DECREASEALLOWANCE":
                 // increaseAllowance {spender} {addedValue}
-                Transactions.decreaseAllowance(token, args[1], Long.parseLong(args[2]));
+                transactions.decreaseAllowance(token, args[1], Long.parseLong(args[2]));
                 break;
             case "TRANSFERFROM":
                 // transferFrom {fromAddress} {toAddress} {amount}
-                Transactions.transferFrom(token, args[1], args[2], Long.parseLong(args[3]));
+                transactions.transferFrom(token, args[1], args[2], Long.parseLong(args[3]));
                 break;
             case "BURN":
                 // burn {amount}
-                Transactions.burn(token, Long.parseLong(args[1]));
+                transactions.burn(token, Long.parseLong(args[1]));
                 break;
             case "JOIN":
                 // join {topicId}

--- a/src/main/java/com/hedera/hcstoken/HederaMirror.java
+++ b/src/main/java/com/hedera/hcstoken/HederaMirror.java
@@ -41,7 +41,6 @@ import java.time.Instant;
  */
 public final class HederaMirror {
     private static final String MIRROR_NODE_ADDRESS = Dotenv.configure().ignoreIfMissing().load().get("MIRROR_NODE_ADDRESS");
-    private static final MirrorClient mirrorClient = new MirrorClient(MIRROR_NODE_ADDRESS);
 
     /**
      * Subscribes to a mirror node and sleeps for a few seconds to allow notifications to come through
@@ -51,6 +50,8 @@ public final class HederaMirror {
      * @throws Exception: in the event of an error
      */
     public static void subscribe(Token token, long seconds) throws Exception {
+        final MirrorClient mirrorClient = new MirrorClient(MIRROR_NODE_ADDRESS);
+
         if (token.getTopicId().isEmpty()) {
             return;
         }

--- a/src/main/java/com/hedera/hcstoken/HederaMirror.java
+++ b/src/main/java/com/hedera/hcstoken/HederaMirror.java
@@ -30,6 +30,10 @@ import io.github.cdimascio.dotenv.Dotenv;
 import org.bouncycastle.math.ec.rfc8032.Ed25519;
 import proto.*;
 
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.time.Instant;
 
 /**
@@ -54,7 +58,13 @@ public final class HederaMirror {
         new MirrorConsensusTopicQuery()
                 .setTopicId(ConsensusTopicId.fromString(token.getTopicId()))
                 .setStartTime(startTime)
-                .subscribe(mirrorClient, resp -> handleNotification(token, resp),
+                .subscribe(mirrorClient, resp -> {
+                            try {
+                                handleNotification(token, resp);
+                            } catch (Exception e) {
+                                e.printStackTrace();
+                            }
+                        },
             // On gRPC error, print the stack trace
             Throwable::printStackTrace);
 
@@ -67,92 +77,135 @@ public final class HederaMirror {
      * @param token: The token object
      * @param notification: The notification data from mirror node
      */
-    private static void handleNotification(Token token, MirrorConsensusTopicResponse notification) {
+    private static void handleNotification(Token token, MirrorConsensusTopicResponse notification) throws Exception {
+        processNotification(token, notification.message, notification.consensusTimestamp);
+    }
+
+    /**
+     * Processes notifications from a mirror node
+     * Not strictly necessary, all the processing could take place in handleNotification()
+     * However it's not possible to instantiate a MirrorConsensusTopicResponse meaning
+     * it's not possible to unit test otherwise
+     * @param token: The token object
+     * @param message: The message within the notification
+     * @param consensusTimestamp: The consensus timestamp within the notification
+     */
+    public static void processNotification(Token token, byte[] message, Instant consensusTimestamp) throws Exception {
+        byte[] operationHash = new byte[0];
         try {
-            Primitive primitive = Primitive.parseFrom(notification.message);
-            byte[] signature = primitive.getSignature().toByteArray();
-            String address = primitive.getPublicKey();
-            Ed25519PublicKey signingKey = Ed25519PublicKey.fromString(address);
+            // hash the notification and add to the list of operations
+            // this will throw an exception if the operation has already been processed
+            MessageDigest digest = MessageDigest.getInstance("SHA-384");
+            operationHash = digest.digest(message);
+        } catch (NoSuchAlgorithmException e) {
+            e.printStackTrace();
+            throw e;
+        }
 
-            // set last consensus time stamp
-            token.setLastConsensusSeconds(notification.consensusTimestamp.getEpochSecond());
-            token.setLastConsensusNanos(notification.consensusTimestamp.getNano());
+        // set last consensus time stamp
+        token.setLastConsensusSeconds(consensusTimestamp.getEpochSecond());
+        token.setLastConsensusNanos(consensusTimestamp.getNano());
 
-            try {
-                // Process response
-                if (primitive.hasConstruct()) {
-                    Construct construct = primitive.getConstruct();
-                    if ( ! Ed25519.verify(signature, 0, signingKey.toBytes(), 0, construct.toByteArray(), 0, construct.toByteArray().length)) {
-                        System.out.println("Signature verification on message failed");
-                        return;
-                    }
-                    Primitives.construct(token, address, construct.getName(), construct.getSymbol(), construct.getDecimals());
-                } else if (primitive.hasMint()) {
-                    Mint mint = primitive.getMint();
-                    if ( ! Ed25519.verify(signature, 0, signingKey.toBytes(), 0, mint.toByteArray(), 0, mint.toByteArray().length)) {
-                        System.out.println("Signature verification on message failed");
-                        return;
-                    }
-                    Primitives.mint(token, mint.getAddress(), mint.getQuantity());
-                } else if (primitive.hasTransfer()) {
-                    Transfer transfer = primitive.getTransfer();
-                    if ( ! Ed25519.verify(signature, 0, signingKey.toBytes(), 0, transfer.toByteArray(), 0, transfer.toByteArray().length)) {
-                        System.out.println("Signature verification on message failed");
-                        return;
-                    }
-                    Primitives.transfer(token, primitive.getPublicKey(), transfer.getToAddress(), transfer.getQuantity());
-                } else if (primitive.hasJoin()) {
-                    Join join = primitive.getJoin();
-                    if ( ! Ed25519.verify(signature, 0, signingKey.toBytes(), 0, join.toByteArray(), 0, join.toByteArray().length)) {
-                        System.out.println("Signature verification on message failed");
-                        return;
-                    }
-                    Primitives.join(token, join.getAddress());
-                } else if (primitive.hasApprove()) {
-                    Approve approve = primitive.getApprove();
-                    if ( ! Ed25519.verify(signature, 0, signingKey.toBytes(), 0, approve.toByteArray(), 0, approve.toByteArray().length)) {
-                        System.out.println("Signature verification on message failed");
-                        return;
-                    }
-                    Primitives.approve(token, primitive.getPublicKey(), approve.getSpender(), approve.getAmount());
-                } else if (primitive.hasIncreaseAllowance()) {
-                    IncreaseAllowance increaseAllowance = primitive.getIncreaseAllowance();
-                    if ( ! Ed25519.verify(signature, 0, signingKey.toBytes(), 0, increaseAllowance.toByteArray(), 0, increaseAllowance.toByteArray().length)) {
-                        System.out.println("Signature verification on message failed");
-                        return;
-                    }
-                    Primitives.increaseAllowance(token, primitive.getPublicKey(), increaseAllowance.getSpender(), increaseAllowance.getAddedValue());
-                } else if (primitive.hasDecreaseAllowance()) {
-                    DecreaseAllowance decreaseAllowance = primitive.getDecreaseAllowance();
-                    if ( ! Ed25519.verify(signature, 0, signingKey.toBytes(), 0, decreaseAllowance.toByteArray(), 0, decreaseAllowance.toByteArray().length)) {
-                        System.out.println("Signature verification on message failed");
-                        return;
-                    }
-                    Primitives.decreaseAllowance(token, primitive.getPublicKey(), decreaseAllowance.getSpender(), decreaseAllowance.getSubtractedValue());
-                } else if (primitive.hasTransferFrom()) {
-                    TransferFrom transferFrom = primitive.getTransferFrom();
-                    if ( ! Ed25519.verify(signature, 0, signingKey.toBytes(), 0, transferFrom.toByteArray(), 0, transferFrom.toByteArray().length)) {
-                        System.out.println("Signature verification on message failed");
-                        return;
-                    }
-                    Primitives.transferFrom(token, primitive.getPublicKey(), transferFrom.getFromAddress(), transferFrom.getToAddress(), transferFrom.getAmount());
-                } else if (primitive.hasBurn()) {
-                    Burn burn = primitive.getBurn();
-                    if ( ! Ed25519.verify(signature, 0, signingKey.toBytes(), 0, burn.toByteArray(), 0, burn.toByteArray().length)) {
-                        System.out.println("Signature verification on message failed");
-                        return;
-                    }
-                    Primitives.burn(token, primitive.getPublicKey(), burn.getAmount());
-                } else {
-                    System.out.println("Unable to process mirror notification - unknown primitive");
-                }
-            } catch (Exception e) {
-                System.out.println("An error occurred : " + e.getMessage());
+        try {
+            token.addOperation(operationHash);
+        } catch (Exception e) {
+            if (e.getMessage().equals("Duplicate Operation hash detected")) {
+                System.out.println("Duplicate Operation hash detected - skipping");
+                return;
+            } else {
+                throw e;
             }
+        }
+        Primitive primitive = null;
+        try {
+            primitive = Primitive.parseFrom(message);
         } catch (Exception e) {
             System.out.println("Unable to process mirror notification - unknown message type");
             e.printStackTrace();
+            return;
         }
 
+        byte[] signature = primitive.getHeader().getSignature().toByteArray();
+        String address = primitive.getHeader().getPublicKey();
+        Ed25519PublicKey signingKey = Ed25519PublicKey.fromString(address);
+
+        try {
+            // Process response
+            Long random = primitive.getHeader().getRandom();
+            if (primitive.hasConstruct()) {
+                Construct construct = primitive.getConstruct();
+                if ( ! signatureValid(primitive.getHeader().getSignature().toByteArray(), signingKey, construct.toByteArray(), random)) {
+                    return;
+                }
+                Primitives.construct(token, address, construct.getName(), construct.getSymbol(), construct.getDecimals());
+            } else if (primitive.hasMint()) {
+                Mint mint = primitive.getMint();
+                if ( ! signatureValid(primitive.getHeader().getSignature().toByteArray(), signingKey, mint.toByteArray(), random)) {
+                    return;
+                }
+                Primitives.mint(token, mint.getAddress(), mint.getQuantity());
+            } else if (primitive.hasTransfer()) {
+                Transfer transfer = primitive.getTransfer();
+                if ( ! signatureValid(primitive.getHeader().getSignature().toByteArray(), signingKey, transfer.toByteArray(), random)) {
+                    return;
+                }
+                Primitives.transfer(token, primitive.getHeader().getPublicKey(), transfer.getToAddress(), transfer.getQuantity());
+            } else if (primitive.hasJoin()) {
+                Join join = primitive.getJoin();
+                if ( ! signatureValid(primitive.getHeader().getSignature().toByteArray(), signingKey, join.toByteArray(), random)) {
+                    return;
+                }
+                Primitives.join(token, join.getAddress());
+            } else if (primitive.hasApprove()) {
+                Approve approve = primitive.getApprove();
+                if ( ! signatureValid(primitive.getHeader().getSignature().toByteArray(), signingKey, approve.toByteArray(), random)) {
+                    return;
+                }
+                Primitives.approve(token, primitive.getHeader().getPublicKey(), approve.getSpender(), approve.getAmount());
+            } else if (primitive.hasIncreaseAllowance()) {
+                IncreaseAllowance increaseAllowance = primitive.getIncreaseAllowance();
+                if ( ! signatureValid(primitive.getHeader().getSignature().toByteArray(), signingKey, increaseAllowance.toByteArray(), random)) {
+                    return;
+                }
+                Primitives.increaseAllowance(token, primitive.getHeader().getPublicKey(), increaseAllowance.getSpender(), increaseAllowance.getAddedValue());
+            } else if (primitive.hasDecreaseAllowance()) {
+                DecreaseAllowance decreaseAllowance = primitive.getDecreaseAllowance();
+                if ( ! signatureValid(primitive.getHeader().getSignature().toByteArray(), signingKey, decreaseAllowance.toByteArray(), random)) {
+                    return;
+                }
+                Primitives.decreaseAllowance(token, primitive.getHeader().getPublicKey(), decreaseAllowance.getSpender(), decreaseAllowance.getSubtractedValue());
+            } else if (primitive.hasTransferFrom()) {
+                TransferFrom transferFrom = primitive.getTransferFrom();
+                if ( ! signatureValid(primitive.getHeader().getSignature().toByteArray(), signingKey, transferFrom.toByteArray(), random)) {
+                    return;
+                }
+                Primitives.transferFrom(token, primitive.getHeader().getPublicKey(), transferFrom.getFromAddress(), transferFrom.getToAddress(), transferFrom.getAmount());
+            } else if (primitive.hasBurn()) {
+                Burn burn = primitive.getBurn();
+                if ( ! signatureValid(primitive.getHeader().getSignature().toByteArray(), signingKey, burn.toByteArray(), random)) {
+                    return;
+                }
+                Primitives.burn(token, primitive.getHeader().getPublicKey(), burn.getAmount());
+            } else {
+                System.out.println("Unable to process mirror notification - unknown primitive");
+            }
+        } catch (Exception e) {
+            System.out.println("An error occurred : " + e.getMessage());
+        }
+    }
+
+    private static boolean signatureValid(byte[] signature, Ed25519PublicKey publicKey, byte[] toVerify, long random) throws IOException {
+        byte[] randomString = String.valueOf(random).getBytes("UTF-8");
+        // concatenate random long with data to sign
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream( );
+        outputStream.write(toVerify);
+        outputStream.write(randomString);
+        // verify the result
+        if ( ! Ed25519.verify(signature, 0, publicKey.toBytes(), 0, outputStream.toByteArray(), 0, outputStream.toByteArray().length)) {
+            System.out.println("Signature verification on message failed");
+            return false;
+        } else {
+            return true;
+        }
     }
 }

--- a/src/main/java/com/hedera/hcstoken/state/Token.java
+++ b/src/main/java/com/hedera/hcstoken/state/Token.java
@@ -20,6 +20,7 @@ package com.hedera.hcstoken.state;
  * ‍
  */
 
+import org.bouncycastle.util.encoders.Hex;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -35,6 +36,7 @@ public final class Token {
     private String name = "";
     private int decimals = 0;
     private Map<String, Address> addresses = new HashMap<String, Address>();
+    private Map<String, String> operations = new HashMap<String, String>();
     // AppNet specifics
     private long lastConsensusSeconds = 0;
     private int lastConsensusNanos = 0;
@@ -102,6 +104,22 @@ public final class Token {
             return this.addresses.get(publicKey);
         } catch (NullPointerException e) {
             return null;
+        }
+    }
+    public Map<String, String> getOperations() {
+        return this.operations;
+    }
+    public void setOperations(Map<String, String> operations) {
+        this.operations = operations;
+    }
+
+    public void addOperation(byte[] operationHash) throws Exception {
+
+        String operation = Hex.toHexString(operationHash);
+        if (this.operations.containsKey(operation)) {
+            throw new Exception("Duplicate Operation hash detected " + operation);
+        } else {
+            this.operations.put(operation, "");
         }
     }
 

--- a/src/main/proto/messages.proto
+++ b/src/main/proto/messages.proto
@@ -49,19 +49,24 @@ message Join {
   string address = 1;
 }
 
-message Primitive {
+message PrimitiveHeader {
   bytes signature = 1;
   string publicKey = 2;
+  uint64 random = 3;
+}
+
+message Primitive {
+  PrimitiveHeader header = 1;
 
   oneof primitive {
-    Construct construct = 3;
-    Mint mint = 4;
-    Transfer transfer = 5;
-    Join join = 6;
-    Approve approve = 7;
-    IncreaseAllowance increaseAllowance = 8;
-    DecreaseAllowance decreaseAllowance = 9;
-    TransferFrom transferFrom = 10;
-    Burn burn = 11;
+    Construct construct = 10;
+    Mint mint = 11;
+    Transfer transfer = 12;
+    Join join = 13;
+    Approve approve = 14;
+    IncreaseAllowance increaseAllowance = 15;
+    DecreaseAllowance decreaseAllowance = 16;
+    TransferFrom transferFrom = 17;
+    Burn burn = 18;
   }
 }

--- a/src/test/java/com/hedera/hcstoken/AbstractTestData.java
+++ b/src/test/java/com/hedera/hcstoken/AbstractTestData.java
@@ -23,6 +23,7 @@ package com.hedera.hcstoken;
 import com.hedera.hashgraph.sdk.crypto.ed25519.Ed25519PrivateKey;
 
 import java.io.File;
+import java.time.Instant;
 
 public abstract class AbstractTestData {
     final File stateFile = new File(getClass().getClassLoader().getResource("test.json").getFile());
@@ -34,11 +35,10 @@ public abstract class AbstractTestData {
     final int decimals = 10;
     final long lastConsensusSeconds = 1589301202;
     final int lastConsensusNanos = 955026000;
+    final Instant consensusTimestamp = Instant.ofEpochSecond(this.lastConsensusSeconds).plusNanos(this.lastConsensusNanos);
 
-    final String pubKeyOwner = "302a300506032b65700321006e42135c6c7c9162a5f96f6d693677742fd0b3f160e1168cc28f2dadaa9e79cc";
     final long ownerBalance = 980;
 
-    final String pubKeyOther = "302a300506032b65700321009308a434a9cac34e2f7ce95fc671bfbbaa4e43760880c4f1ad5a58a0b3932232";
     final long otherBalance = 20;
 
     final long quantity = 1;
@@ -49,4 +49,14 @@ public abstract class AbstractTestData {
 
     final String operatorId = "0.0.999";
     final Ed25519PrivateKey operatorKey = Ed25519PrivateKey.generate();
+    final String pubKeyOwner = operatorKey.publicKey.toString();
+
+    final Ed25519PrivateKey operatorKeyOther = Ed25519PrivateKey.generate();
+    final String pubKeyOther = operatorKeyOther.publicKey.toString();
+
+    final long randomLong = 1234567890;
+
+    public void setTestData(Transactions transactions) {
+        transactions.setTestData(this.topicId, this.operatorId, this.operatorKey, this.randomLong);
+    }
 }

--- a/src/test/java/com/hedera/hcstoken/HederaMirrorTest.java
+++ b/src/test/java/com/hedera/hcstoken/HederaMirrorTest.java
@@ -1,0 +1,214 @@
+package com.hedera.hcstoken;
+
+/*-
+ * ‌
+ * hcs-token-example
+ * ​
+ * Copyright (C) 2020 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.hedera.hashgraph.sdk.crypto.ed25519.Ed25519PrivateKey;
+import com.hedera.hcstoken.state.Token;
+import org.junit.jupiter.api.*;
+import proto.*;
+
+import java.time.Instant;
+
+public class HederaMirrorTest extends AbstractTestData {
+    @Test
+    public void testDuplicate() throws Exception {
+        Transactions transactions = new Transactions();
+        setTestData(transactions);
+        Token token = new Token();
+        Primitives.construct(token, this.pubKeyOwner, this.name, this.symbol, this.decimals);
+        Primitives.mint(token, this.pubKeyOwner, this.quantity);
+
+        Primitive primitive = transactions.transfer(token, this.pubKeyOther, this.transferAmount);
+        HederaMirror.processNotification(token, primitive.toByteArray(), this.consensusTimestamp);
+        Assertions.assertEquals(this.transferAmount, token.getAddress(this.pubKeyOther).getBalance());
+        // duplicate
+        // create new consensus Timestamp
+        Instant newConsensusTimeStamp = this.consensusTimestamp.plusSeconds(20);
+        try {
+            HederaMirror.processNotification(token, primitive.toByteArray(), newConsensusTimeStamp);
+            Assertions.fail("Should have detected duplicate operation");
+        } catch (Exception e) {
+            Assertions.assertTrue(e.getMessage().contains("Duplicate Operation hash detected"));
+            // no change to balance
+            Assertions.assertEquals(this.transferAmount, token.getAddress(this.pubKeyOther).getBalance());
+            // consensus timestamp updated
+            Assertions.assertEquals(newConsensusTimeStamp.getEpochSecond(), token.getLastConsensusSeconds());
+            Assertions.assertEquals(newConsensusTimeStamp.getNano(), token.getLastConsensusNanos());
+        }
+    }
+
+    @Test
+    public void testInvalidMessage() throws Exception {
+        Transactions transactions = new Transactions();
+        setTestData(transactions);
+        Token token = new Token();
+        Assertions.assertEquals(0, token.getLastConsensusSeconds());
+        Assertions.assertEquals(0, token.getLastConsensusNanos());
+
+        HederaMirror.processNotification(token, "Invalid message".getBytes("UTF-8"), this.consensusTimestamp);
+        Assertions.assertEquals(this.lastConsensusSeconds, token.getLastConsensusSeconds());
+        Assertions.assertEquals(this.lastConsensusNanos, token.getLastConsensusNanos());
+    }
+
+    @Test
+    public void testConstruct() throws Exception {
+        Transactions transactions = new Transactions();
+        setTestData(transactions);
+        Token token = new Token();
+
+        Primitive primitive = transactions.construct(token, this.name, this.symbol, this.decimals);
+        HederaMirror.processNotification(token, primitive.toByteArray(), this.consensusTimestamp);
+        Assertions.assertEquals(this.name, token.getName());
+        Assertions.assertEquals(this.lastConsensusSeconds, token.getLastConsensusSeconds());
+        Assertions.assertEquals(this.lastConsensusNanos, token.getLastConsensusNanos());
+    }
+
+    @Test
+    public void testMint() throws Exception {
+        Transactions transactions = new Transactions();
+        setTestData(transactions);
+        Token token = new Token();
+        Primitives.construct(token, this.pubKeyOwner, this.name, this.symbol, this.decimals);
+
+        Primitive primitive = transactions.mint(token, this.quantity);
+        HederaMirror.processNotification(token, primitive.toByteArray(), this.consensusTimestamp);
+        Assertions.assertNotEquals(0, token.getTotalSupply());
+        Assertions.assertEquals(this.lastConsensusSeconds, token.getLastConsensusSeconds());
+        Assertions.assertEquals(this.lastConsensusNanos, token.getLastConsensusNanos());
+    }
+
+    @Test
+    public void testTransfer() throws Exception {
+        Transactions transactions = new Transactions();
+        setTestData(transactions);
+        Token token = new Token();
+        Primitives.construct(token, this.pubKeyOwner, this.name, this.symbol, this.decimals);
+        Primitives.mint(token, this.pubKeyOwner, this.quantity);
+
+        Primitive primitive = transactions.transfer(token, this.pubKeyOther, this.transferAmount);
+        HederaMirror.processNotification(token, primitive.toByteArray(), this.consensusTimestamp);
+        Assertions.assertEquals(this.transferAmount, token.getAddress(this.pubKeyOther).getBalance());
+        Assertions.assertEquals(this.lastConsensusSeconds, token.getLastConsensusSeconds());
+        Assertions.assertEquals(this.lastConsensusNanos, token.getLastConsensusNanos());
+    }
+
+    @Test
+    public void testJoin() throws Exception {
+        Transactions transactions = new Transactions();
+        setTestData(transactions);
+        Token token = new Token();
+        Primitives.construct(token, this.pubKeyOwner, this.name, this.symbol, this.decimals);
+        Primitives.mint(token, this.pubKeyOwner, this.quantity);
+
+        Primitive primitive = transactions.join(token, this.pubKeyOther);
+        HederaMirror.processNotification(token, primitive.toByteArray(), this.consensusTimestamp);
+        Assertions.assertEquals(2, token.getAddresses().size());
+        Assertions.assertEquals(0, token.getAddress(this.pubKeyOther).getBalance());
+        Assertions.assertEquals(this.lastConsensusSeconds, token.getLastConsensusSeconds());
+        Assertions.assertEquals(this.lastConsensusNanos, token.getLastConsensusNanos());
+    }
+
+    @Test
+    public void testApprove() throws Exception {
+        Transactions transactions = new Transactions();
+        setTestData(transactions);
+        Token token = new Token();
+        Primitives.construct(token, this.pubKeyOwner, this.name, this.symbol, this.decimals);
+        Primitives.mint(token, this.pubKeyOwner, this.quantity);
+        Primitives.join(token, this.pubKeyOther);
+
+        Primitive primitive = transactions.approve(token, this.pubKeyOther, this.approveAmount);
+        HederaMirror.processNotification(token, primitive.toByteArray(), this.consensusTimestamp);
+        Assertions.assertEquals(1, token.getAddress(this.pubKeyOwner).getAllowances().size());
+        Assertions.assertEquals(this.approveAmount, token.getAddress(this.pubKeyOwner).getAllowance(this.pubKeyOther));
+        Assertions.assertEquals(this.lastConsensusSeconds, token.getLastConsensusSeconds());
+        Assertions.assertEquals(this.lastConsensusNanos, token.getLastConsensusNanos());
+    }
+
+    @Test
+    public void testIncreaseAllowance() throws Exception {
+        Transactions transactions = new Transactions();
+        setTestData(transactions);
+        Token token = new Token();
+        Primitives.construct(token, this.pubKeyOwner, this.name, this.symbol, this.decimals);
+        Primitives.mint(token, this.pubKeyOwner, this.quantity);
+        Primitives.join(token, this.pubKeyOther);
+        Primitives.approve(token, this.pubKeyOwner, this.pubKeyOther, this.approveAmount);
+
+        Primitive primitive = transactions.increaseAllowance(token, this.pubKeyOther, this.allowance);
+        HederaMirror.processNotification(token, primitive.toByteArray(), this.consensusTimestamp);
+        Assertions.assertEquals(this.approveAmount + this.allowance, token.getAddress(this.pubKeyOwner).getAllowance(this.pubKeyOther));
+        Assertions.assertEquals(this.lastConsensusSeconds, token.getLastConsensusSeconds());
+        Assertions.assertEquals(this.lastConsensusNanos, token.getLastConsensusNanos());
+    }
+
+    @Test
+    public void testDecreaseAllowance() throws Exception {
+        Transactions transactions = new Transactions();
+        setTestData(transactions);
+        Token token = new Token();
+        Primitives.construct(token, this.pubKeyOwner, this.name, this.symbol, this.decimals);
+        Primitives.mint(token, this.pubKeyOwner, this.quantity);
+        Primitives.join(token, this.pubKeyOther);
+        Primitives.approve(token, this.pubKeyOwner, this.pubKeyOther, this.approveAmount);
+
+        Primitive primitive = transactions.decreaseAllowance(token, this.pubKeyOther, this.allowance);
+        HederaMirror.processNotification(token, primitive.toByteArray(), this.consensusTimestamp);
+        Assertions.assertEquals(this.approveAmount - this.allowance, token.getAddress(this.pubKeyOwner).getAllowance(this.pubKeyOther));
+        Assertions.assertEquals(this.lastConsensusSeconds, token.getLastConsensusSeconds());
+        Assertions.assertEquals(this.lastConsensusNanos, token.getLastConsensusNanos());
+    }
+    @Test
+    public void testTransferFrom() throws Exception {
+        Transactions transactions = new Transactions();
+        transactions.setTestData(this.topicId, this.operatorId, this.operatorKey, this.randomLong);
+        Token token = new Token();
+        Primitives.construct(token, this.pubKeyOwner, this.name, this.symbol, this.decimals);
+        Primitives.mint(token, this.pubKeyOwner, this.quantity);
+        Primitives.join(token, this.pubKeyOther);
+        Primitives.approve(token, this.pubKeyOwner, this.pubKeyOther, this.approveAmount);
+
+        // switch user
+        transactions.setTestData(this.topicId, this.operatorId, this.operatorKeyOther, this.randomLong);
+        Primitive primitive = transactions.transferFrom(token, this.pubKeyOwner, this.pubKeyOther, this.transferAmount);
+        HederaMirror.processNotification(token, primitive.toByteArray(), this.consensusTimestamp);
+        Assertions.assertEquals(this.approveAmount - this.transferAmount, token.getAddress(this.pubKeyOwner).getAllowance(this.pubKeyOther));
+        Assertions.assertEquals(this.transferAmount, token.getAddress(this.pubKeyOther).getBalance());
+        Assertions.assertEquals(this.lastConsensusSeconds, token.getLastConsensusSeconds());
+        Assertions.assertEquals(this.lastConsensusNanos, token.getLastConsensusNanos());
+    }
+    @Test
+    public void testBurn() throws Exception {
+        Transactions transactions = new Transactions();
+        setTestData(transactions);
+        Token token = new Token();
+        Primitives.construct(token, this.pubKeyOwner, this.name, this.symbol, this.decimals);
+        Primitives.mint(token, this.pubKeyOwner, this.quantity);
+        long currentBalance = token.getAddress(this.pubKeyOwner).getBalance();
+
+        Primitive primitive = transactions.burn(token, this.burnAmount);
+        HederaMirror.processNotification(token, primitive.toByteArray(), this.consensusTimestamp);
+        Assertions.assertEquals(currentBalance - this.burnAmount, token.getAddress(this.pubKeyOwner).getBalance());
+        Assertions.assertEquals(this.lastConsensusSeconds, token.getLastConsensusSeconds());
+        Assertions.assertEquals(this.lastConsensusNanos, token.getLastConsensusNanos());
+    }
+}

--- a/src/test/java/com/hedera/hcstoken/TransactionsTest.java
+++ b/src/test/java/com/hedera/hcstoken/TransactionsTest.java
@@ -20,18 +20,21 @@ package com.hedera.hcstoken;
  * ‍
  */
 
-import com.google.protobuf.ByteString;
 import com.hedera.hcstoken.state.Token;
 import org.junit.jupiter.api.*;
 import proto.*;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 
 public class TransactionsTest extends AbstractTestData {
 
     @Test
     public void testConstruct() throws Exception {
-        Transactions.setTestData(this.topicId, this.operatorId, this.operatorKey);
+        Transactions transactions = new Transactions();
+        setTestData(transactions);
         Token token = new Token();
-        Primitive primitive = Transactions.construct(token, name, symbol, decimals);
+        Primitive primitive = transactions.construct(token, name, symbol, decimals);
 
         Assertions.assertEquals(this.topicId, token.getTopicId());
 
@@ -41,14 +44,14 @@ public class TransactionsTest extends AbstractTestData {
                 .setDecimals(decimals)
                 .build();
 
-        byte[] signature = operatorKey.sign(construct.toByteArray());
-
         Assertions.assertArrayEquals(construct.toByteArray(), primitive.getConstruct().toByteArray());
+
+        byte[] signature = signature(construct.toByteArray());
         checkSigAndKey(signature, primitive);
 
         // construct again, should fail
         try {
-            Transactions.construct(token, name, symbol, decimals);
+            transactions.construct(token, name, symbol, decimals);
             Assertions.fail("Second construction should have thrown error");
         } catch (Exception e) {
             Assertions.assertTrue(e.getMessage().contains("Topic ID is already set, you cannot overwrite"));
@@ -57,12 +60,13 @@ public class TransactionsTest extends AbstractTestData {
 
     @Test
     public void testJoin() throws Exception {
-        Transactions.setTestData(this.topicId, this.operatorId, this.operatorKey);
+        Transactions transactions = new Transactions();
+        setTestData(transactions);
         Token token = new Token();
 
         // join with empty address
         try {
-            Transactions.join(token, "");
+            transactions.join(token, "");
             Assertions.fail("Join with empty address should have thrown error");
         } catch (Exception e) {
             Assertions.assertTrue(e.getMessage().contains("Cannot join with an empty address"));
@@ -72,17 +76,17 @@ public class TransactionsTest extends AbstractTestData {
                 .setAddress(this.pubKeyOther)
                 .build();
 
-        byte[] signature = operatorKey.sign(join.toByteArray());
-
-        Primitive primitive = Transactions.join(token, this.pubKeyOther);
-
+        Primitive primitive = transactions.join(token, this.pubKeyOther);
         Assertions.assertArrayEquals(join.toByteArray(), primitive.getJoin().toByteArray());
+
+        byte[] signature = signature(join.toByteArray());
         checkSigAndKey(signature, primitive);
     }
 
     @Test
     public void testMint() throws Exception {
-        Transactions.setTestData(this.topicId, this.operatorId, this.operatorKey);
+        Transactions transactions = new Transactions();
+        setTestData(transactions);
         Token token = new Token();
 
         Mint mint = Mint.newBuilder()
@@ -90,17 +94,16 @@ public class TransactionsTest extends AbstractTestData {
                 .setQuantity(this.quantity)
                 .build();
 
-        byte[] signature = operatorKey.sign(mint.toByteArray());
-
-        Primitive primitive = Transactions.mint(token, this.quantity);
-
+        Primitive primitive = transactions.mint(token, this.quantity);
         Assertions.assertArrayEquals(mint.toByteArray(), primitive.getMint().toByteArray());
+
+        byte[] signature = signature(mint.toByteArray());
         checkSigAndKey(signature, primitive);
 
         // mint again for error
         try {
             token.setTotalSupply(this.totalSupply);
-            Transactions.mint(token, this.quantity);
+            transactions.mint(token, this.quantity);
             Assertions.fail("Already minted token should fail");
         } catch (Exception e) {
             Assertions.assertTrue(e.getMessage().contains("Token already minted"));
@@ -109,7 +112,8 @@ public class TransactionsTest extends AbstractTestData {
 
     @Test
     public void testTransfer() throws Exception {
-        Transactions.setTestData(this.topicId, this.operatorId, this.operatorKey);
+        Transactions transactions = new Transactions();
+        setTestData(transactions);
         Token token = new Token();
 
         Transfer transfer = Transfer.newBuilder()
@@ -117,17 +121,17 @@ public class TransactionsTest extends AbstractTestData {
                 .setQuantity(this.quantity)
                 .build();
 
-        byte[] signature = this.operatorKey.sign(transfer.toByteArray());
-
-        Primitive primitive = Transactions.transfer(token, this.pubKeyOther, this.quantity);
-
+        Primitive primitive = transactions.transfer(token, this.pubKeyOther, this.quantity);
         Assertions.assertArrayEquals(transfer.toByteArray(), primitive.getTransfer().toByteArray());
+
+        byte[] signature = signature(transfer.toByteArray());
         checkSigAndKey(signature, primitive);
     }
 
     @Test
     public void testApprove() throws Exception {
-        Transactions.setTestData(this.topicId, this.operatorId, this.operatorKey);
+        Transactions transactions = new Transactions();
+        setTestData(transactions);
         Token token = new Token();
 
         Approve approve = Approve.newBuilder()
@@ -135,17 +139,17 @@ public class TransactionsTest extends AbstractTestData {
                 .setAmount(this.approveAmount)
                 .build();
 
-        byte[] signature = this.operatorKey.sign(approve.toByteArray());
-
-        Primitive primitive = Transactions.approve(token, this.pubKeyOther, this.approveAmount);
-
+        Primitive primitive = transactions.approve(token, this.pubKeyOther, this.approveAmount);
         Assertions.assertArrayEquals(approve.toByteArray(), primitive.getApprove().toByteArray());
+
+        byte[] signature = signature(approve.toByteArray());
         checkSigAndKey(signature, primitive);
     }
 
     @Test
     public void testIncreaseAllowance() throws Exception {
-        Transactions.setTestData(this.topicId, this.operatorId, this.operatorKey);
+        Transactions transactions = new Transactions();
+        setTestData(transactions);
         Token token = new Token();
 
         IncreaseAllowance increaseAllowance = IncreaseAllowance.newBuilder()
@@ -153,17 +157,17 @@ public class TransactionsTest extends AbstractTestData {
                 .setAddedValue(this.allowance)
                 .build();
 
-        byte[] signature = this.operatorKey.sign(increaseAllowance.toByteArray());
-
-        Primitive primitive = Transactions.increaseAllowance(token, this.pubKeyOther, this.allowance);
-
+        Primitive primitive = transactions.increaseAllowance(token, this.pubKeyOther, this.allowance);
         Assertions.assertArrayEquals(increaseAllowance.toByteArray(), primitive.getIncreaseAllowance().toByteArray());
+
+        byte[] signature = signature(increaseAllowance.toByteArray());
         checkSigAndKey(signature, primitive);
     }
 
     @Test
     public void testDecreaseAllowance() throws Exception {
-        Transactions.setTestData(this.topicId, this.operatorId, this.operatorKey);
+        Transactions transactions = new Transactions();
+        setTestData(transactions);
         Token token = new Token();
 
         DecreaseAllowance decreaseAllowance = DecreaseAllowance.newBuilder()
@@ -171,17 +175,17 @@ public class TransactionsTest extends AbstractTestData {
                 .setSubtractedValue(this.allowance)
                 .build();
 
-        byte[] signature = this.operatorKey.sign(decreaseAllowance.toByteArray());
-
-        Primitive primitive = Transactions.decreaseAllowance(token, this.pubKeyOther, this.allowance);
-
+        Primitive primitive = transactions.decreaseAllowance(token, this.pubKeyOther, this.allowance);
         Assertions.assertArrayEquals(decreaseAllowance.toByteArray(), primitive.getDecreaseAllowance().toByteArray());
+
+        byte[] signature = signature(decreaseAllowance.toByteArray());
         checkSigAndKey(signature, primitive);
     }
 
     @Test
     public void testTransferFrom() throws Exception {
-        Transactions.setTestData(this.topicId, this.operatorId, this.operatorKey);
+        Transactions transactions = new Transactions();
+        setTestData(transactions);
         Token token = new Token();
 
         TransferFrom transferFrom = TransferFrom.newBuilder()
@@ -190,33 +194,45 @@ public class TransactionsTest extends AbstractTestData {
                 .setAmount(this.transferAmount)
                 .build();
 
-        byte[] signature = this.operatorKey.sign(transferFrom.toByteArray());
-
-        Primitive primitive = Transactions.transferFrom(token, this.operatorKey.publicKey.toString(), this.pubKeyOther, this.transferAmount);
-
+        Primitive primitive = transactions.transferFrom(token, this.operatorKey.publicKey.toString(), this.pubKeyOther, this.transferAmount);
         Assertions.assertArrayEquals(transferFrom.toByteArray(), primitive.getTransferFrom().toByteArray());
+
+        byte[] signature = signature(transferFrom.toByteArray());
         checkSigAndKey(signature, primitive);
     }
 
     @Test
     public void testBurn() throws Exception {
-        Transactions.setTestData(this.topicId, this.operatorId, this.operatorKey);
+        Transactions transactions = new Transactions();
+        setTestData(transactions);
         Token token = new Token();
 
         Burn burn = Burn.newBuilder()
                 .setAmount(this.burnAmount)
                 .build();
 
-        byte[] signature = this.operatorKey.sign(burn.toByteArray());
 
-        Primitive primitive = Transactions.burn(token, this.burnAmount);
-
+        Primitive primitive = transactions.burn(token, this.burnAmount);
         Assertions.assertArrayEquals(burn.toByteArray(), primitive.getBurn().toByteArray());
+
+        byte[] signature = signature(burn.toByteArray());
         checkSigAndKey(signature, primitive);
     }
 
     private void checkSigAndKey(byte[] signature, Primitive primitive) {
-        Assertions.assertArrayEquals(signature, primitive.getSignature().toByteArray());
-        Assertions.assertEquals(operatorKey.publicKey.toString(), primitive.getPublicKey());
+        Assertions.assertArrayEquals(signature, primitive.getHeader().getSignature().toByteArray());
+        Assertions.assertEquals(operatorKey.publicKey.toString(), primitive.getHeader().getPublicKey());
     }
+
+    private byte[] signature(byte[] toSign) throws IOException {
+        // get a random long into a byte array
+        byte[] randomString = String.valueOf(this.randomLong).getBytes("UTF-8");
+        // concatenate random long with data to sign
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream( );
+        outputStream.write( toSign );
+        outputStream.write( randomString );
+        // sign the result
+        return this.operatorKey.sign(outputStream.toByteArray( ));
+    }
+
 }


### PR DESCRIPTION
Signed-off-by: Greg Scullard <gregscullard@hedera.com>

**Detailed description**:
Per issue description, this change ensures that sending an identical operation (same signature, etc...) twice won't result in a double spend.

**Which issue(s) this PR fixes**:
Fixes #17 

**Checklist**
- [ ] Documentation added
- [X] Tests updated

